### PR TITLE
Convert [symbols.template] from a property to a method.

### DIFF
--- a/demos/src/BrowserPluginList.js
+++ b/demos/src/BrowserPluginList.js
@@ -86,7 +86,7 @@ class BrowserPluginList extends base {
 
   // Define a template that will be stamped into the Shadow DOM by the
   // ShadowTemplateMixin.
-  get [symbols.template]() {
+  [symbols.template]() {
     return `
       <style>
       :host {

--- a/demos/src/FocusRingTest.js
+++ b/demos/src/FocusRingTest.js
@@ -5,7 +5,7 @@ import symbols from '../../mixins/symbols.js';
 
 class FocusRingTest extends FocusRingMixin(ShadowTemplateMixin(HTMLElement)) {
 
-  get [symbols.template]() {
+  [symbols.template]() {
     return `
       <style>
         :host {

--- a/demos/src/ToolbarTab.js
+++ b/demos/src/ToolbarTab.js
@@ -4,7 +4,7 @@ import symbols from '../../mixins/symbols.js';
 
 
 class ToolbarTab extends FocusRingMixin(ShadowTemplateMixin(HTMLElement)) {
-  get [symbols.template]() {
+  [symbols.template](filler) {
     return `
       <style>
         :host {
@@ -36,7 +36,7 @@ class ToolbarTab extends FocusRingMixin(ShadowTemplateMixin(HTMLElement)) {
       </style>
 
       <button tabindex="-1">
-        <slot></slot>
+        ${filler || `<slot></slot>`}
       </button>
     `;
   }

--- a/elements/LabeledTabButton.js
+++ b/elements/LabeledTabButton.js
@@ -14,7 +14,7 @@ import symbols from '../mixins/symbols.js';
  * @mixes ShadowTemplateMixin
  */
 class LabeledTabButton extends FocusRingMixin(ShadowTemplateMixin(HTMLElement)) {
-  get [symbols.template]() {
+  [symbols.template](filler) {
     return `
       <style>
         :host {
@@ -36,7 +36,7 @@ class LabeledTabButton extends FocusRingMixin(ShadowTemplateMixin(HTMLElement)) 
           outline: none;
           padding: 0.5em 0.75em;
           position: relative;
-          transition: border-color 0.25s;
+          effect: border-color 0.25s;
         }
 
         :host(.selected) button {
@@ -98,7 +98,7 @@ class LabeledTabButton extends FocusRingMixin(ShadowTemplateMixin(HTMLElement)) 
       </style>
 
       <button tabindex="-1">
-        <slot></slot>
+        ${filler || `<slot></slot>`}
       </button>
     `;
   }

--- a/elements/LabeledTabs.js
+++ b/elements/LabeledTabs.js
@@ -60,20 +60,24 @@ class LabeledTabs extends Tabs {
   // https://github.com/w3c/webcomponents/issues/631. This bug comes into play
   // when a LabeledTabs component has tabAlign set to "stretch". We work around
   // this bug by adding a style rule that explicitly styles slot children.
-  get [symbols.template]() {
-    let baseTemplate = super[symbols.template] || '';
-    if (baseTemplate instanceof HTMLTemplateElement) {
-      baseTemplate = baseTemplate.innerHTML; // Downgrade to string.
-    }
-    return `
-      ${baseTemplate}
+  [symbols.template](fillers) {
+    const defaultFiller = typeof fillers === 'string' ?
+      fillers :
+      (fillers && fillers.default) || `<slot></slot>`;
+    const tabButtonsFiller = fillers && fillers.tabButtons;
+    /* Styling workaround: see note above */
+    const template = `
+      ${defaultFiller}
       <style>
-        /* Workaround: see note above */
         :host([tab-align="stretch"]) slot[name="tabButtons"] > * {
           flex: 1;
         }
       </style>
     `;
+    return super[symbols.template]({
+      default: template,
+      tabButtons: tabButtonsFiller
+    });
   }
 
 }

--- a/elements/ListBox.js
+++ b/elements/ListBox.js
@@ -100,7 +100,7 @@ class ListBox extends Base {
     }
   }
 
-  get [symbols.template]() {
+  [symbols.template](filler) {
     return `
       <style>
       :host {
@@ -139,7 +139,7 @@ class ListBox extends Base {
       </style>
 
       <div id="itemsContainer" role="none">
-        <slot></slot>
+        ${filler || `<slot></slot>`}
       </div>
     `;
   }

--- a/elements/Modes.js
+++ b/elements/Modes.js
@@ -56,14 +56,14 @@ class Modes extends Base {
     // item.setAttribute('aria-hidden', !selected);
   }
 
-  get [symbols.template]() {
+  [symbols.template](filler) {
     return `
       <style>
         :host {
           display: inline-block;
         }
       </style>
-      <slot></slot>
+      ${filler || `<slot></slot>`}
     `;
   }
 

--- a/elements/TabStrip.js
+++ b/elements/TabStrip.js
@@ -93,11 +93,6 @@ class TabStrip extends Base {
     item.setAttribute('tabindex', 0);
   }
 
-  // [symbols.itemsChanged]() {
-  //   if (super[symbols.itemsChanged]) { super[symbols.itemsChanged](); }
-  //   console.log(this.items);
-  // }
-
   [symbols.itemSelected](item, selected) {
     if (super[symbols.itemSelected]) { super[symbols.itemSelected](item, selected); }
     if (selected) {
@@ -170,7 +165,7 @@ class TabStrip extends Base {
     });
   }
 
-  get [symbols.template]() {
+  [symbols.template](filler) {
     return `
       <style>
         :host {
@@ -217,7 +212,7 @@ class TabStrip extends Base {
       </style>
 
       <div id="tabButtonContainer" role="none">
-        <slot></slot>
+        ${filler || `<slot></slot>`}
       </div>
     `;
   }

--- a/elements/TabStripWrapper.js
+++ b/elements/TabStripWrapper.js
@@ -148,18 +148,18 @@ export default function TabStripWrapper(Base) {
       return this.$.tabStrip;
     }
 
-    get [symbols.template]() {
-      let baseTemplate = super[symbols.template] || '';
-      if (baseTemplate instanceof HTMLTemplateElement) {
-        baseTemplate = baseTemplate.innerHTML; // Downgrade to string.
-      }
-      return `
+    [symbols.template](fillers = {}) {
+      const defaultFiller = typeof fillers === 'string' ?
+        fillers :
+        fillers.default || `<slot></slot>`;
+      const tabButtonsFiller = fillers.tabButtons || `<slot name="tabButtons"></slot>`;
+      return super[symbols.template](`
         <elix-tab-strip id="tabStrip">
-          <slot name="tabButtons"></slot>
+          ${tabButtonsFiller}
         </elix-tab-strip>
 
         <div id="pages">
-          ${baseTemplate}
+          ${defaultFiller}
         </div>
 
         <style>
@@ -193,7 +193,7 @@ export default function TabStripWrapper(Base) {
             box-sizing: border-box;
           }
         </style>
-      `;
+      `);
     }
 
   }

--- a/mixins/DefaultSlotContentMixin.js
+++ b/mixins/DefaultSlotContentMixin.js
@@ -19,8 +19,7 @@ const slotchangeFiredSymbol = Symbol('slotchangeFired');
  * Example:
  *
  * ```
- * let base = DefaultSlotContentMixin(HTMLElement);
- * class CountingElement extends base {
+ * class CountingElement extends DefaultSlotContentMixin(HTMLElement) {
  *
  *   constructor() {
  *     super();

--- a/mixins/ShadowTemplateMixin.js
+++ b/mixins/ShadowTemplateMixin.js
@@ -14,18 +14,18 @@ const mapTagToTemplate = {};
  * Mixin which adds stamping a template into a Shadow DOM subtree upon component
  * instantiation.
  *
- * To use this mixin, define a `template` property as a string or HTML
+ * To use this mixin, define a `template` method that returns a string or HTML
  * `<template>` element:
  *
  *     class MyElement extends ShadowTemplateMixin(HTMLElement) {
- *       get [symbols.template]() {
+ *       [symbols.template]() {
  *         return `Hello, <em>world</em>.`;
  *       }
  *     }
  *
  * When your component class is instantiated, a shadow root will be created on
  * the instance, and the contents of the template will be cloned into the
- * shadow root. If your component does not define a `template` property, this
+ * shadow root. If your component does not define a `template` method, this
  * mixin has no effect.
  *
  * @module ShadowTemplateMixin
@@ -51,9 +51,9 @@ export default function ShadowTemplateMixin(Base) {
         // This is the first time we've created an instance of this tag.
 
         // Get the template and perform initial processing.
-        template = this[symbols.template];
+        template = this[symbols.template]();
         if (!template) {
-          console.warn(`ShadowTemplateMixin expects a component to define a property called [symbols.template].`);
+          console.warn(`ShadowTemplateMixin expects a component to define a method called [symbols.template].`);
           return;
         }
 

--- a/mixins/symbols.js
+++ b/mixins/symbols.js
@@ -260,13 +260,23 @@ const symbols = {
   shadowCreated: Symbol('shadowCreated'),
 
   /**
-   * Symbol for the `template` property.
+   * Symbol for the `template` method.
    *
-   * This property returns a component's template.
+   * This method should return a component's template.
    *
+   * @param {string|object} [filler]
    * @type {string|HTMLTemplateElement}
    */
-  template: Symbol('template')
+  template: Symbol('template'),
+
+  // TODO: documentation
+  afterEffect: Symbol('afterEffect'),
+  applyEffect: Symbol('applyEffect'),
+  beforeEffect: Symbol('beforeEffect'),
+  cancelEffect: Symbol('cancelEffect'),
+  currentEffect: Symbol('currentEffect'),
+  showEffect: Symbol('showEffect'),
+  openedChanged: Symbol('openedChanged')
 };
 
 export default symbols;

--- a/test/mixins/DefaultSlotContentMixin.tests.js
+++ b/test/mixins/DefaultSlotContentMixin.tests.js
@@ -24,7 +24,7 @@ class DefaultSlotContentTest extends DefaultSlotContentMixin(ShadowTemplateMixin
     this.contentChangedCallCount++;
   }
 
-  get [symbols.template]() {
+  [symbols.template]() {
     return `
       <div id="static">This is static content</div>
       <slot></slot>
@@ -40,7 +40,7 @@ customElements.define('default-slot-content-test', DefaultSlotContentTest);
  * changes in final distribution (not just direct slot assignments).
  */
 class WrappedContentTest extends ShadowTemplateMixin(HTMLElement) {
-  get [symbols.template]() {
+  [symbols.template]() {
     return `<default-slot-content-test><slot></slot></default-slotcontent-test>`;
   }
 }

--- a/test/mixins/ShadowTemplateMixin.tests.js
+++ b/test/mixins/ShadowTemplateMixin.tests.js
@@ -6,7 +6,7 @@ import ShadowTemplateMixin from '../../mixins/ShadowTemplateMixin.js';
 
 /* Element with a simple template */
 class ElementWithStringTemplate extends ShadowTemplateMixin(HTMLElement) {
-  get [symbols.template]() {
+  [symbols.template]() {
     return "<div>Hello</div>";
   }
 }
@@ -17,7 +17,7 @@ customElements.define('element-with-string-template', ElementWithStringTemplate)
 const template = document.createElement('template');
 template.innerHTML = "Hello";
 class ElementWithRealTemplate extends ShadowTemplateMixin(HTMLElement) {
-  get [symbols.template]() {
+  [symbols.template]() {
     return template;
   }
 }
@@ -26,7 +26,7 @@ customElements.define('element-with-real-template', ElementWithRealTemplate);
 
 /* Element with styles to polyfill. */
 class ElementWithStylesInTemplate extends ShadowTemplateMixin(HTMLElement) {
-  get [symbols.template]() {
+  [symbols.template]() {
     return `
       <style>
         /* Use a style that will get polyfilled. */

--- a/test/mixins/content.tests.js
+++ b/test/mixins/content.tests.js
@@ -8,7 +8,7 @@ import symbols from '../../mixins/symbols.js';
  * Simple element with a slot.
  */
 class ChildrenTest extends ShadowTemplateMixin(HTMLElement) {
-  get [symbols.template]() {
+  [symbols.template]() {
     return `
       <div id="static">This is static content</div>
       <slot></slot>
@@ -22,7 +22,7 @@ customElements.define('children-test', ChildrenTest);
  * Element containing an instance of the above, so we can test redistribution.
  */
 class RedistributionTest extends ShadowTemplateMixin(HTMLElement) {
-  get [symbols.template]() {
+  [symbols.template]() {
     return `<children-test><slot></slot></children-test>`;
   }
 }


### PR DESCRIPTION
The core change here is to `ShadowTemplateMixin`, which currently expects a component to define a property called `[symbols.template]`. The mixin invokes this property's getter to obtain a component's template. The proposed change is to convert this property to a method so that it can accept parameters.

The purpose of this change is to better accommodate component subclassing. While Elix generally prefers mixins for composition rather than a traditional class hierarchy, there are cases where a subclass is a simpler solution than creating an entirely new component that duplicates another component's set of mixins.

For example, sometimes one desires to create a component that's nearly identical to another component, but includes some additional content. To use a canonical example, suppose I have a MyButton component, and I now want to create a MyIconButton variant that includes an icon. MyIconButton wants to reuse the MyButton code, but partially fill in MyButton's default `slot`.

The proposed solution is to allow MyIconButton to subclass MyButton, and give it a means to partially fill in MyButton's template. This is done by letting MyButton's `[symbols.template]` method accept an optional parameter. The MyIconButton subclass can invoke its base class' template method and pass in the content that should be used in place of MyButton's default slot.

```
class MyButton extends HTMLElement {
  [symbols.template](filler) {
    return `
      <button>
        ${filler || `<slot></slot>`}
      </button>
    `;
  }
}

class MyIconButton extends MyButton {
  [symbols.template]() {
    return super[symbols.template](`
      <img src="icon.png">
      <slot></slot>
    `);
  }  
}
```

If one instantiates MyButton directly, the `filler` parameter will be `undefined`, and its template method returns:

    <button>
      <slot></slot>
    </button>

If one instantiates MyIconButton, its template method invokes MyButton's template method, passing in some filler content. MyIconButton's template method returns:

    <button>
      <img src="icon.png">
      <slot></slot>
    </button>

The interpretation of the parameter for `[symbols.template]` is up to the component — `ShadowTemplateMixin` doesn't care about the parameter. In fact, other component class collections could define more elaborate conventions with multiple parameters. The point is that `ShadowTemplateMixin` enables such schemes by invoking a template method instead of getting a template property.

This change is intended to support the ongoing work on overlay mixins, where the scenario comes up a number of times. Supporting `[symbols.template]` as a method simplifies the code in a number of overlay components.

This constitutes a breaking change for any component using `ShadowTemplateMixin`. The fix is generally simple: change the signature of the component's template from a property

    get [symbols.template]() { ... }

to a method

    [symbols.template]() { ... }

This PR includes the above fix for all existing components. Anyone using `ShadowTemplateMixin` outside this repo would need to apply this change to their own components.