### PR TITLE
No saucelabs-tests for PRs, only headless-tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ node_js:
 before_script:
 - webpack
 script:
-- node tasks/sauce-tests.js
+- npm run ci
 addons:
   sauce_connect: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
 before_script:
 - webpack
 script:
-- npm run ci
+- 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then npm run ci:fast; fi'
+- 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then npm run ci; fi'
 addons:
   sauce_connect: true

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test": "node tasks/headless-tests.js",
     "typecheck": "tsc",
     "watch": "webpack --watch",
-    "ci": "npm run lint && npm run sauce-tests"
+    "ci": "npm run lint && npm run sauce-tests",
+    "ci:fast": "npm run lint && npm run test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "start": "static-server . --port 3000",
     "test": "node tasks/headless-tests.js",
     "typecheck": "tsc",
-    "watch": "webpack --watch"
+    "watch": "webpack --watch",
+    "ci": "npm run lint && npm run sauce-tests"
   }
 }


### PR DESCRIPTION
To **make PRs less heavy and faster** to run the tests run for PRs use only the headless tests.
Just when running on master the saucelabs tests are run.

Feel free to close it without merging if this makes no sense :).