### PR TITLE
Code clean up: Separate static webserver into own file

### DIFF
--- a/tasks/headless-tests.js
+++ b/tasks/headless-tests.js
@@ -1,17 +1,6 @@
 const puppeteer = require('puppeteer');
 const runInCi = process.argv.indexOf('--run-in-ci');
-
-const getPort = require('get-port');
-const path = require('path');
-const StaticServer = require('static-server');
-const startStaticHttpServer = async () => {
-  const server = new StaticServer({
-    rootPath: path.join(__dirname, '..'),
-    port: await getPort()
-  });
-  await new Promise((resolve) => {server.start(resolve);});
-  return {stop: () => server.stop(), port: server.port};
-};
+const startStaticHttpServer = require('./static-webserver').start;
 
 const runTestsInHeadlessChrome = async (port) => {
   const argsNeededForTravisToWork = ['--no-sandbox']; // thx. see https://github.com/GoogleChrome/puppeteer/issues/536#issuecomment-324945531
@@ -30,7 +19,7 @@ const runTestsInHeadlessChrome = async (port) => {
 };
 
 (async () => {
-  const server = await startStaticHttpServer();
+  const server = await startStaticHttpServer({directory: __dirname});
   const testResult = await runTestsInHeadlessChrome(server.port);
   if (testResult === 'OK') {
     console.log('Tests passed.');

--- a/tasks/headless-tests.js
+++ b/tasks/headless-tests.js
@@ -1,6 +1,7 @@
 const puppeteer = require('puppeteer');
 const runInCi = process.argv.indexOf('--run-in-ci');
-const startStaticHttpServer = require('./static-webserver').start;
+const startStaticWebserver = require('./static-webserver').start;
+const path = require('path');
 
 const runTestsInHeadlessChrome = async (port) => {
   const argsNeededForTravisToWork = ['--no-sandbox']; // thx. see https://github.com/GoogleChrome/puppeteer/issues/536#issuecomment-324945531
@@ -19,7 +20,8 @@ const runTestsInHeadlessChrome = async (port) => {
 };
 
 (async () => {
-  const server = await startStaticHttpServer({directory: __dirname});
+  const testFilesDirectory = path.join(__dirname, '..');
+  const server = await startStaticWebserver({directory: testFilesDirectory});
   const testResult = await runTestsInHeadlessChrome(server.port);
   if (testResult === 'OK') {
     console.log('Tests passed.');

--- a/tasks/headless-tests.js
+++ b/tasks/headless-tests.js
@@ -10,7 +10,7 @@ const startStaticHttpServer = async () => {
     port: await getPort()
   });
   await new Promise((resolve) => {server.start(resolve);});
-  return server;
+  return {stop: () => server.stop(), port: server.port};
 };
 
 const runTestsInHeadlessChrome = async (port) => {

--- a/tasks/headless-tests.js
+++ b/tasks/headless-tests.js
@@ -1,7 +1,7 @@
 const puppeteer = require('puppeteer');
-const getPort = require('get-port');
 const runInCi = process.argv.indexOf('--run-in-ci');
 
+const getPort = require('get-port');
 const path = require('path');
 const StaticServer = require('static-server');
 const startStaticHttpServer = async () => {

--- a/tasks/headless-tests.js
+++ b/tasks/headless-tests.js
@@ -1,9 +1,9 @@
 const puppeteer = require('puppeteer');
-const path = require('path');
 const getPort = require('get-port');
-const StaticServer = require('static-server');
 const runInCi = process.argv.indexOf('--run-in-ci');
 
+const path = require('path');
+const StaticServer = require('static-server');
 const startStaticHttpServer = async () => {
   const server = new StaticServer({
     rootPath: path.join(__dirname, '..'),

--- a/tasks/static-webserver.js
+++ b/tasks/static-webserver.js
@@ -1,10 +1,9 @@
 const getPort = require('get-port');
-const path = require('path');
 const StaticServer = require('static-server');
 
 const start = async ({directory}) => {
   const server = new StaticServer({
-    rootPath: path.join(directory, '..'),
+    rootPath: directory,
     port: await getPort()
   });
   await new Promise((resolve) => {server.start(resolve);});

--- a/tasks/static-webserver.js
+++ b/tasks/static-webserver.js
@@ -1,0 +1,14 @@
+const getPort = require('get-port');
+const path = require('path');
+const StaticServer = require('static-server');
+
+const start = async ({directory}) => {
+  const server = new StaticServer({
+    rootPath: path.join(directory, '..'),
+    port: await getPort()
+  });
+  await new Promise((resolve) => {server.start(resolve);});
+  return {stop: () => server.stop(), port: server.port};
+};
+
+module.exports = {start};


### PR DESCRIPTION
Basically a clean up task. Move the static webserver part out of the `headless-tests.js`, since it is only a utility part of it and should not be part of the test runner itself.