### PR TITLE
added `duration` property documentation to the Toast element

### DIFF
--- a/src/Toast.js
+++ b/src/Toast.js
@@ -53,7 +53,16 @@ class Toast extends Base {
       fromEdge: 'bottom',
     });
   }
-
+  /**
+   * The duration in which the toast will appear on screen
+   * 
+   * The `duration` value refers to the duration of time in which the toast
+   * will appear on the screen. In other words, this is the time between 
+   * the `opened` and `closed` event for the toast.
+   * 
+   * @type {number}
+   * @default null
+   */
   get duration() {
     return this.state.duration;
   }


### PR DESCRIPTION
I noticed that the duration property is missing on [the Toast docs page](https://component.kitchen/elix/Toast), so I added some docs in the source code.