### PR TITLE
Make typechecks work on tests too

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
     "describe": false,
     "it": false,
     "mocha": false,
+    "require": false,
     "sinon": false,
     "ResizeObserver": false
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,12 +111,6 @@
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
       "dev": true
     },
-    "@types/node": {
-      "version": "13.1.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.7.tgz",
-      "integrity": "sha512-HU0q9GXazqiKwviVxg9SI/+t/nAsGkvLDkIdxz+ObejG2nX6Si00TeLqHMoS+a/1tjH7a8YpKVQwtgHuMQsldg==",
-      "dev": true
-    },
     "@types/sinon": {
       "version": "7.5.1",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.1.tgz",
@@ -2750,7 +2744,7 @@
         "lodash": "~3.7.0",
         "q": "~1.3.0",
         "requestretry": "~1.2.2",
-        "sauce-connect-tunnel": "github:componentkitchen/sauce-connect-tunnel"
+        "sauce-connect-tunnel": "github:componentkitchen/sauce-connect-tunnel#d1aed73079ade37ba55fc0393c8bd451de9679a7"
       },
       "dependencies": {
         "lodash": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,6 +99,12 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@types/chai": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.7.tgz",
+      "integrity": "sha512-luq8meHGYwvky0O7u0eQZdA7B4Wd9owUCqvbw2m3XCrCU8mplYOujMBbvyS547AxJkC+pGnd0Cm15eNxEUNU8g==",
+      "dev": true
+    },
     "@types/mocha": {
       "version": "5.2.7",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,6 +117,12 @@
       "integrity": "sha512-HU0q9GXazqiKwviVxg9SI/+t/nAsGkvLDkIdxz+ObejG2nX6Si00TeLqHMoS+a/1tjH7a8YpKVQwtgHuMQsldg==",
       "dev": true
     },
+    "@types/sinon": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.1.tgz",
+      "integrity": "sha512-EZQUP3hSZQyTQRfiLqelC9NMWd1kqLcmQE0dMiklxBkgi84T+cHOhnKpgk4NnOWpGX863yE6+IaGnOXUNFqDnQ==",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,6 +99,18 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@types/mocha": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "13.1.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.7.tgz",
+      "integrity": "sha512-HU0q9GXazqiKwviVxg9SI/+t/nAsGkvLDkIdxz+ObejG2nX6Si00TeLqHMoS+a/1tjH7a8YpKVQwtgHuMQsldg==",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "devDependencies": {
     "@types/chai": "^4.2.7",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^13.1.7",
     "@types/sinon": "^7.5.1",
     "chai": "4.2.0",
     "eslint": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "toast"
   ],
   "devDependencies": {
+    "@types/mocha": "^5.2.7",
+    "@types/node": "^13.1.7",
     "chai": "4.2.0",
     "eslint": "6.3.0",
     "express": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/chai": "^4.2.7",
     "@types/mocha": "^5.2.7",
     "@types/node": "^13.1.7",
+    "@types/sinon": "^7.5.1",
     "chai": "4.2.0",
     "eslint": "6.3.0",
     "express": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "toast"
   ],
   "devDependencies": {
+    "@types/chai": "^4.2.7",
     "@types/mocha": "^5.2.7",
     "@types/node": "^13.1.7",
     "chai": "4.2.0",

--- a/src/AutoCompleteInput.d.ts
+++ b/src/AutoCompleteInput.d.ts
@@ -4,3 +4,4 @@
 import Input from "./Input.js";
 
 export default class AutoCompleteInput extends Input {}
+export function autoComplete(AutoCompleteInput);

--- a/src/AutoSizeTextarea.d.ts
+++ b/src/AutoSizeTextarea.d.ts
@@ -5,5 +5,5 @@ import WrappedStandardElement from "./WrappedStandardElement.js";
 
 export default class AutoSizeTextarea extends WrappedStandardElement {
   minimumRows: number;
-  value: number;
+  value: string;
 }

--- a/test/chai.js
+++ b/test/chai.js
@@ -1,0 +1,2 @@
+// use this file to split when run in the browser vs. run on node
+export { assert } from "chai";

--- a/test/chai.js
+++ b/test/chai.js
@@ -1,2 +1,0 @@
-// use this file to split when run in the browser vs. run on node
-export { assert } from "chai";

--- a/test/storyboards/RenderState.js
+++ b/test/storyboards/RenderState.js
@@ -28,6 +28,7 @@ class RenderState extends Base {
 
       // Look for an element (or subelement) with class "fixture".
       const fixtures = elements
+        // @ts-ignore I have no idea what the tsc error means here :(
         .map(element =>
           element.classList.contains("fixture")
             ? element

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -1,0 +1,15 @@
+// use this file to split when run in the browser vs. run on node
+
+let assert;
+let sinon;
+if (typeof window === "undefined") {
+    assert = require("chai").assert;
+    sinon = require("sinon");
+} else {
+    // @ts-ignore
+    assert = window.assert;
+    // @ts-ignore
+    sinon = window.sinon;
+}
+
+export { assert, sinon };

--- a/test/tests/AriaListMixin.tests.js
+++ b/test/tests/AriaListMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import AriaListMixin from "../../src/AriaListMixin.js";
 import ContentItemsMixin from "../../src/ContentItemsMixin.js";

--- a/test/tests/AriaListMixin.tests.js
+++ b/test/tests/AriaListMixin.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import AriaListMixin from "../../src/AriaListMixin.js";
 import ContentItemsMixin from "../../src/ContentItemsMixin.js";

--- a/test/tests/AttributeMarshallingMixin.tests.js
+++ b/test/tests/AttributeMarshallingMixin.tests.js
@@ -1,4 +1,4 @@
-import {assert} from '../chai.js';
+import { assert } from '../test-helpers.js';
 import AttributeMarshallingMixin from "../../src/AttributeMarshallingMixin.js";
 
 let defaultPropertyValue;

--- a/test/tests/AttributeMarshallingMixin.tests.js
+++ b/test/tests/AttributeMarshallingMixin.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import {assert} from '../chai.js';
 import AttributeMarshallingMixin from "../../src/AttributeMarshallingMixin.js";
 
 let defaultPropertyValue;
@@ -44,8 +44,7 @@ describe("AttributeMarshallingMixin", () => {
   });
 
   it("defines observedAttributes for all custom property setters", () => {
-    const observedAttributes = ElementWithCustomProperty.observedAttributes;
-    assert.deepEqual(observedAttributes, ["custom-property", "disabled"]);
+    assert.deepNestedPropertyVal(ElementWithCustomProperty, "observedAttributes", ["custom-property", "disabled"]);
   });
 
   it("marshals hyphenated attribute to corresponding camelCase property", () => {

--- a/test/tests/AttributeMarshallingMixin.tests.js
+++ b/test/tests/AttributeMarshallingMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import AttributeMarshallingMixin from "../../src/AttributeMarshallingMixin.js";
 
 let defaultPropertyValue;

--- a/test/tests/AutoCompleteInput.tests.js
+++ b/test/tests/AutoCompleteInput.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import {
   default as AutoCompleteInput,
   autoComplete

--- a/test/tests/AutoCompleteInput.tests.js
+++ b/test/tests/AutoCompleteInput.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import {
   default as AutoCompleteInput,
   autoComplete

--- a/test/tests/AutoSizeTextarea.tests.js
+++ b/test/tests/AutoSizeTextarea.tests.js
@@ -26,7 +26,7 @@ describe("AutoSizeTextarea", () => {
     const fixture = new AutoSizeTextarea();
     fixture.value = "beaver";
     fixture[internal.renderChanges]();
-    assert(fixture.inner.value, "beaver");
+    assert.propertyVal(fixture.inner ,"value", "beaver");
   });
 
   it("updates value when innerHTML changes", async () => {
@@ -126,7 +126,7 @@ describe("AutoSizeTextarea", () => {
     container.appendChild(fixture);
     fixture.placeholder = "Placeholder";
     await Promise.resolve();
-    assert.equal(fixture.inner.placeholder, "Placeholder");
+    assert.propertyVal(fixture.inner , "placeholder", "Placeholder");
     assert.notEqual(fixture.value, "Placeholder");
   });
 });

--- a/test/tests/AutoSizeTextarea.tests.js
+++ b/test/tests/AutoSizeTextarea.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import AutoSizeTextarea from "../../define/AutoSizeTextarea.js";
 

--- a/test/tests/AutoSizeTextarea.tests.js
+++ b/test/tests/AutoSizeTextarea.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import AutoSizeTextarea from "../../define/AutoSizeTextarea.js";
 

--- a/test/tests/CalendarDayNamesHeader.tests.js
+++ b/test/tests/CalendarDayNamesHeader.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import { trimMarks } from "../normalize.js";
 import * as internal from "../../src/internal.js";
 import CalendarDayNamesHeader from "../../define/CalendarDayNamesHeader.js";

--- a/test/tests/CalendarDayNamesHeader.tests.js
+++ b/test/tests/CalendarDayNamesHeader.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import { trimMarks } from "../normalize.js";
 import * as internal from "../../src/internal.js";
 import CalendarDayNamesHeader from "../../define/CalendarDayNamesHeader.js";

--- a/test/tests/CalendarDays.tests.js
+++ b/test/tests/CalendarDays.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as calendar from "../../src/calendar.js";
 import * as internal from "../../src/internal.js";
 import CalendarDays from "../../define/CalendarDays.js";

--- a/test/tests/CalendarDays.tests.js
+++ b/test/tests/CalendarDays.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as calendar from "../../src/calendar.js";
 import * as internal from "../../src/internal.js";
 import CalendarDays from "../../define/CalendarDays.js";

--- a/test/tests/CalendarDays.tests.js
+++ b/test/tests/CalendarDays.tests.js
@@ -11,10 +11,10 @@ describe("CalendarDays", () => {
     await fixture[internal.renderChanges]();
     assert.equal(31, fixture.days.length);
     const lastDay = fixture.days[30];
-    assert(calendar.datesEqual(lastDay.date, new Date("31 Jan 2019")));
+    assert(calendar.datesEqual(lastDay["date"], new Date("31 Jan 2019")));
     const dateInRange = new Date("15 January 2019");
     const dayElementInRange = fixture.dayElementForDate(dateInRange);
-    assert(fixture.days[14], dayElementInRange);
+    assert.equal(fixture.days[14], dayElementInRange);
     const dateOutOfRange = new Date("1 Jan 2016");
     assert.isUndefined(fixture.dayElementForDate(dateOutOfRange));
   });
@@ -24,9 +24,9 @@ describe("CalendarDays", () => {
     fixture.locale = "en-US"; // Weeks start on Sunday
     fixture.startDate = new Date("10 March 2015"); // A Tuesday
     await fixture[internal.renderChanges]();
-    assert.equal(fixture.days[0].style.gridColumnStart, "3");
+    assert.equal(fixture.days[0]["style"].gridColumnStart, "3");
     fixture.locale = "en-GB"; // Weeks start on Monday
     await fixture[internal.renderChanges]();
-    assert.equal(fixture.days[0].style.gridColumnStart, "2");
+    assert.equal(fixture.days[0]["style"].gridColumnStart, "2");
   });
 });

--- a/test/tests/CalendarMonthYearHeader.tests.js
+++ b/test/tests/CalendarMonthYearHeader.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import { trimMarks } from "../normalize.js";
 import * as internal from "../../src/internal.js";
 import CalendarMonthYearHeader from "../../define/CalendarMonthYearHeader.js";

--- a/test/tests/CalendarMonthYearHeader.tests.js
+++ b/test/tests/CalendarMonthYearHeader.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import { trimMarks } from "../normalize.js";
 import * as internal from "../../src/internal.js";
 import CalendarMonthYearHeader from "../../define/CalendarMonthYearHeader.js";

--- a/test/tests/ContentItemsMixin.tests.js
+++ b/test/tests/ContentItemsMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import ContentItemsMixin from "../../src/ContentItemsMixin.js";
 import ReactiveMixin from "../../src/ReactiveMixin.js";

--- a/test/tests/ContentItemsMixin.tests.js
+++ b/test/tests/ContentItemsMixin.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import ContentItemsMixin from "../../src/ContentItemsMixin.js";
 import ReactiveMixin from "../../src/ReactiveMixin.js";

--- a/test/tests/DarkModeMixin.tests.js
+++ b/test/tests/DarkModeMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import DarkModeMixin from "../../src/DarkModeMixin.js";
 import ReactiveMixin from "../../src/ReactiveMixin.js";

--- a/test/tests/DarkModeMixin.tests.js
+++ b/test/tests/DarkModeMixin.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import DarkModeMixin from "../../src/DarkModeMixin.js";
 import ReactiveMixin from "../../src/ReactiveMixin.js";

--- a/test/tests/DateComboBox.tests.js
+++ b/test/tests/DateComboBox.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as calendar from "../../src/calendar.js";
 import DateComboBox from "../../define/DateComboBox.js";
 

--- a/test/tests/DateComboBox.tests.js
+++ b/test/tests/DateComboBox.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as calendar from "../../src/calendar.js";
 import DateComboBox from "../../define/DateComboBox.js";
 

--- a/test/tests/DelegateFocusMixin.tests.js
+++ b/test/tests/DelegateFocusMixin.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import * as template from "../../src/template.js";
 import DelegateFocusMixin from "../../src/DelegateFocusMixin.js";

--- a/test/tests/DelegateFocusMixin.tests.js
+++ b/test/tests/DelegateFocusMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import * as template from "../../src/template.js";
 import DelegateFocusMixin from "../../src/DelegateFocusMixin.js";

--- a/test/tests/DirectionSelectionMixin.tests.js
+++ b/test/tests/DirectionSelectionMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import DirectionSelectionMixin from "../../src/DirectionSelectionMixin.js";
 

--- a/test/tests/DirectionSelectionMixin.tests.js
+++ b/test/tests/DirectionSelectionMixin.tests.js
@@ -1,5 +1,4 @@
-import { assert } from '../chai.js';
-import sinon from "sinon";
+import { assert, sinon } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import DirectionSelectionMixin from "../../src/DirectionSelectionMixin.js";
 

--- a/test/tests/DirectionSelectionMixin.tests.js
+++ b/test/tests/DirectionSelectionMixin.tests.js
@@ -1,4 +1,5 @@
 import { assert } from '../chai.js';
+import sinon from "sinon";
 import * as internal from "../../src/internal.js";
 import DirectionSelectionMixin from "../../src/DirectionSelectionMixin.js";
 

--- a/test/tests/Explorer.tests.js
+++ b/test/tests/Explorer.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import Explorer from "../../define/Explorer.js";
 
 describe("Explorer", () => {

--- a/test/tests/Explorer.tests.js
+++ b/test/tests/Explorer.tests.js
@@ -25,7 +25,7 @@ describe("Explorer", () => {
     container.appendChild(fixture);
     // Wait for component to render.
     // Wait for content, which requires event/timeout timing.
-    await new Promise(setTimeout);
+    await new Promise((resolve) => { setTimeout(resolve); });
     const proxies = fixture.proxies;
     assert.equal(proxies.length, 3);
     assert.equal(proxies[0], fixture.children[0]);
@@ -42,7 +42,7 @@ describe("Explorer", () => {
     container.appendChild(fixture);
     // Wait for component to render.
     // Wait for content, which requires event/timeout timing.
-    await new Promise(setTimeout);
+    await new Promise((resolve) => { setTimeout(resolve); });
     const proxies = fixture.proxies;
     assert.equal(proxies.length, 3);
     assert(proxies[0] instanceof HTMLButtonElement);

--- a/test/tests/Explorer.tests.js
+++ b/test/tests/Explorer.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import Explorer from "../../define/Explorer.js";
 
 describe("Explorer", () => {

--- a/test/tests/FormElementMixin.tests.js
+++ b/test/tests/FormElementMixin.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import FormElementMixin from "../../src/FormElementMixin.js";
 import ReactiveElement from "../../src/ReactiveElement.js";

--- a/test/tests/FormElementMixin.tests.js
+++ b/test/tests/FormElementMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import FormElementMixin from "../../src/FormElementMixin.js";
 import ReactiveElement from "../../src/ReactiveElement.js";

--- a/test/tests/FormElementMixin.tests.js
+++ b/test/tests/FormElementMixin.tests.js
@@ -66,7 +66,7 @@ customElements.define("form-element-test", FormElementTest);
     fixture.value = "aardvark";
     fixture[internal.renderChanges]();
     form.addEventListener("formdata", event => {
-      assert(event.formData.get("animal"), "aardvark");
+      assert(event["formData"].get("animal"), "aardvark");
       done();
     });
     form.submit();
@@ -75,7 +75,7 @@ customElements.define("form-element-test", FormElementTest);
   it("participates in validation", () => {
     const fixture = new FormElementTest();
     fixture[internal.renderChanges]();
-    assert(!fixture.checkValidity());
+    assert.isFalse(fixture.checkValidity());
     fixture.value = "bandicoot";
     fixture[internal.renderChanges]();
     assert(fixture.checkValidity());

--- a/test/tests/KeyboardDirectionMixin.tests.js
+++ b/test/tests/KeyboardDirectionMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import KeyboardDirectionMixin from "../../src/KeyboardDirectionMixin.js";
 

--- a/test/tests/KeyboardDirectionMixin.tests.js
+++ b/test/tests/KeyboardDirectionMixin.tests.js
@@ -1,5 +1,4 @@
-import { assert } from '../chai.js';
-import sinon from "sinon";
+import { assert, sinon } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import KeyboardDirectionMixin from "../../src/KeyboardDirectionMixin.js";
 

--- a/test/tests/KeyboardDirectionMixin.tests.js
+++ b/test/tests/KeyboardDirectionMixin.tests.js
@@ -1,11 +1,12 @@
 import { assert } from '../chai.js';
+import sinon from "sinon";
 import * as internal from "../../src/internal.js";
 import KeyboardDirectionMixin from "../../src/KeyboardDirectionMixin.js";
 
 class KeyboardDirectionMixinTest extends KeyboardDirectionMixin(HTMLElement) {
   constructor() {
     super();
-    this[internal.state] = {};
+    this[internal.state] = { orientation: "" };
   }
 
   [internal.goRight]() {

--- a/test/tests/KeyboardMixin.tests.js
+++ b/test/tests/KeyboardMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import * as mockInteractions from "../mockInteractions.js";
 import KeyboardMixin from "../../src/KeyboardMixin.js";

--- a/test/tests/KeyboardMixin.tests.js
+++ b/test/tests/KeyboardMixin.tests.js
@@ -46,7 +46,7 @@ describe("KeyboardMixin", () => {
 
   it("listens to keydown and fires the keydown() method", done => {
     const fixture = new KeyboardTest();
-    fixture[internal.keydown] = (evt) => {
+    fixture[internal.keydown] = () => {
       done();
       return true;
     };

--- a/test/tests/KeyboardMixin.tests.js
+++ b/test/tests/KeyboardMixin.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import * as mockInteractions from "../mockInteractions.js";
 import KeyboardMixin from "../../src/KeyboardMixin.js";

--- a/test/tests/KeyboardMixin.tests.js
+++ b/test/tests/KeyboardMixin.tests.js
@@ -41,13 +41,14 @@ describe("KeyboardMixin", () => {
     assert.equal(fixture.tabIndex, 1);
     fixture.tabIndex = 2;
     assert.equal(fixture[internal.state].tabIndex, 2);
-    assert.equal(fixture.getAttribute("tabindex"), 2);
+    assert.equal(fixture.getAttribute("tabindex"), "2");
   });
 
   it("listens to keydown and fires the keydown() method", done => {
     const fixture = new KeyboardTest();
-    fixture[internal.keydown] = () => {
+    fixture[internal.keydown] = (evt) => {
       done();
+      return true;
     };
     container.appendChild(fixture);
     mockInteractions.dispatchSyntheticKeyboardEvent(fixture, "keydown");

--- a/test/tests/KeyboardPagedSelectionMixin.tests.js
+++ b/test/tests/KeyboardPagedSelectionMixin.tests.js
@@ -2,10 +2,11 @@ import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import KeyboardPagedSelectionMixin from "../../src/KeyboardPagedSelectionMixin.js";
 import ReactiveMixin from "../../src/ReactiveMixin.js";
+import ShadowTemplateMixin from "../../src/ShadowTemplateMixin.js";
 
 const itemHeight = 100;
 
-const Base = KeyboardPagedSelectionMixin(ReactiveMixin(HTMLElement));
+const Base = KeyboardPagedSelectionMixin(ReactiveMixin(ShadowTemplateMixin(HTMLElement)));
 
 class KeyboardPagedSelectionTest extends Base {
   connectedCallback() {

--- a/test/tests/KeyboardPagedSelectionMixin.tests.js
+++ b/test/tests/KeyboardPagedSelectionMixin.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import KeyboardPagedSelectionMixin from "../../src/KeyboardPagedSelectionMixin.js";
 import ReactiveMixin from "../../src/ReactiveMixin.js";

--- a/test/tests/KeyboardPagedSelectionMixin.tests.js
+++ b/test/tests/KeyboardPagedSelectionMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import KeyboardPagedSelectionMixin from "../../src/KeyboardPagedSelectionMixin.js";
 import ReactiveMixin from "../../src/ReactiveMixin.js";

--- a/test/tests/KeyboardPagedSelectionMixin.tests.js
+++ b/test/tests/KeyboardPagedSelectionMixin.tests.js
@@ -3,7 +3,7 @@ import * as internal from "../../src/internal.js";
 import KeyboardPagedSelectionMixin from "../../src/KeyboardPagedSelectionMixin.js";
 import ReactiveMixin from "../../src/ReactiveMixin.js";
 
-const itemHeight = "100";
+const itemHeight = 100;
 
 const Base = KeyboardPagedSelectionMixin(ReactiveMixin(HTMLElement));
 

--- a/test/tests/KeyboardPrefixSelectionMixin.tests.js
+++ b/test/tests/KeyboardPrefixSelectionMixin.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import ItemsTextMixin from "../../src/ItemsTextMixin.js";
 import KeyboardPrefixSelectionMixin from "../../src/KeyboardPrefixSelectionMixin.js";

--- a/test/tests/KeyboardPrefixSelectionMixin.tests.js
+++ b/test/tests/KeyboardPrefixSelectionMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import ItemsTextMixin from "../../src/ItemsTextMixin.js";
 import KeyboardPrefixSelectionMixin from "../../src/KeyboardPrefixSelectionMixin.js";

--- a/test/tests/LanguageDirectionMixin.tests.js
+++ b/test/tests/LanguageDirectionMixin.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import LanguageDirectionMixin from "../../src/LanguageDirectionMixin.js";
 import ReactiveElement from "../../src/ReactiveElement.js";

--- a/test/tests/LanguageDirectionMixin.tests.js
+++ b/test/tests/LanguageDirectionMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import LanguageDirectionMixin from "../../src/LanguageDirectionMixin.js";
 import ReactiveElement from "../../src/ReactiveElement.js";

--- a/test/tests/ListBox.tests.js
+++ b/test/tests/ListBox.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import * as mockInteractions from "../mockInteractions.js";
 import ListBox from "../../define/ListBox.js";

--- a/test/tests/ListBox.tests.js
+++ b/test/tests/ListBox.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import * as mockInteractions from "../mockInteractions.js";
 import ListBox from "../../define/ListBox.js";

--- a/test/tests/OpenCloseMixin.tests.js
+++ b/test/tests/OpenCloseMixin.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import OpenCloseMixin from "../../src/OpenCloseMixin.js";
 import ReactiveMixin from "../../src/ReactiveMixin.js";
 

--- a/test/tests/OpenCloseMixin.tests.js
+++ b/test/tests/OpenCloseMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import OpenCloseMixin from "../../src/OpenCloseMixin.js";
 import ReactiveMixin from "../../src/ReactiveMixin.js";
 

--- a/test/tests/OverlayMixin.tests.js
+++ b/test/tests/OverlayMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import OpenCloseMixin from "../../src/OpenCloseMixin.js";
 import OverlayMixin from "../../src/OverlayMixin.js";

--- a/test/tests/OverlayMixin.tests.js
+++ b/test/tests/OverlayMixin.tests.js
@@ -50,7 +50,7 @@ describe("OverlayMixin", function() {
 
   it("leaves the z-index alone if one is specified", async () => {
     const fixture = new OverlayTest();
-    fixture.style.zIndex = 10;
+    fixture.style.zIndex = "10";
     container.appendChild(fixture);
     await fixture.open();
     assert.equal(fixture.style.zIndex, "10");

--- a/test/tests/OverlayMixin.tests.js
+++ b/test/tests/OverlayMixin.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import OpenCloseMixin from "../../src/OpenCloseMixin.js";
 import OverlayMixin from "../../src/OverlayMixin.js";

--- a/test/tests/ReactiveMixin.tests.js
+++ b/test/tests/ReactiveMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import ReactiveMixin from "../../src/ReactiveMixin.js";
 

--- a/test/tests/ReactiveMixin.tests.js
+++ b/test/tests/ReactiveMixin.tests.js
@@ -5,6 +5,7 @@ import ReactiveMixin from "../../src/ReactiveMixin.js";
 import State from '../../src/State.js';
 
 class ReactiveTest extends ReactiveMixin(HTMLElement) {
+  static defaults = undefined;
   [internal.componentDidMount]() {
     if (super[internal.componentDidMount]) {
       super[internal.componentDidMount]();
@@ -20,7 +21,7 @@ class ReactiveTest extends ReactiveMixin(HTMLElement) {
   get [internal.defaultState]() {
     return Object.assign(
       super[internal.defaultState],
-      this.constructor.defaults
+      ReactiveTest.defaults
     );
   }
 
@@ -46,7 +47,7 @@ describe("ReactiveMixin", function() {
 
   it("starts with an empty state object", () => {
     const fixture = new ReactiveTest();
-    assert.deepEqual(fixture[internal.state], {});
+    assert.deepEqual(fixture[internal.state], new State({}));
   });
 
   it("starts with defaultState if defined", () => {
@@ -54,7 +55,7 @@ describe("ReactiveMixin", function() {
       message: "aardvark"
     };
     const fixture = new ReactiveTest();
-    assert.deepEqual(fixture[internal.state], { message: "aardvark" });
+    assert.deepEqual(fixture[internal.state], new State({ message: "aardvark" }));
     ReactiveTest.defaults = undefined;
   });
 
@@ -63,12 +64,12 @@ describe("ReactiveMixin", function() {
     fixture[internal.setState]({
       message: "badger"
     });
-    assert.deepEqual(fixture[internal.state], { message: "badger" });
+    assert.deepEqual(fixture[internal.state], new State({ message: "badger" }));
   });
 
   it("state is immutable", () => {
     const fixture = new ReactiveTest();
-    assert.throws(() => (fixture[internal.state] = {}));
+    assert.throws(() => (fixture[internal.state] = new State()));
     assert.throws(() => (fixture[internal.state].message = "chihuahua"));
   });
 

--- a/test/tests/ReactiveMixin.tests.js
+++ b/test/tests/ReactiveMixin.tests.js
@@ -1,5 +1,4 @@
-import { assert } from '../chai.js';
-import sinon from "sinon";
+import { assert, sinon } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import ReactiveMixin from "../../src/ReactiveMixin.js";
 import State from '../../src/State.js';

--- a/test/tests/ReactiveMixin.tests.js
+++ b/test/tests/ReactiveMixin.tests.js
@@ -1,6 +1,8 @@
 import { assert } from '../chai.js';
+import sinon from "sinon";
 import * as internal from "../../src/internal.js";
 import ReactiveMixin from "../../src/ReactiveMixin.js";
+import State from '../../src/State.js';
 
 class ReactiveTest extends ReactiveMixin(HTMLElement) {
   [internal.componentDidMount]() {
@@ -152,7 +154,7 @@ describe("ReactiveMixin", function() {
 
   it("runs state change handlers when state changes", () => {
     // Simple class, copies state member `a` to `b`.
-    class Fixture extends ReactiveMixin(Object) {
+    class Fixture extends ReactiveMixin(HTMLElement) {
       get [internal.defaultState]() {
         const state = super[internal.defaultState];
         state.onChange("a", state => ({ b: state.a }));
@@ -169,7 +171,7 @@ describe("ReactiveMixin", function() {
   });
 
   it("runs state change handlers on initial state", () => {
-    class Fixture extends ReactiveMixin(Object) {
+    class Fixture extends ReactiveMixin(HTMLElement) {
       get [internal.defaultState]() {
         const state = super[internal.defaultState];
         state.a = 1;

--- a/test/tests/ReactiveMixin.tests.js
+++ b/test/tests/ReactiveMixin.tests.js
@@ -5,7 +5,6 @@ import ReactiveMixin from "../../src/ReactiveMixin.js";
 import State from '../../src/State.js';
 
 class ReactiveTest extends ReactiveMixin(HTMLElement) {
-  static defaults = undefined;
   [internal.componentDidMount]() {
     if (super[internal.componentDidMount]) {
       super[internal.componentDidMount]();
@@ -32,6 +31,7 @@ class ReactiveTest extends ReactiveMixin(HTMLElement) {
     this.renderedResult = this[internal.state].message;
   }
 }
+ReactiveTest.defaults = undefined;
 customElements.define("reactive-test", ReactiveTest);
 
 describe("ReactiveMixin", function() {

--- a/test/tests/ReactiveMixin.tests.js
+++ b/test/tests/ReactiveMixin.tests.js
@@ -154,7 +154,8 @@ describe("ReactiveMixin", function() {
 
   it("runs state change handlers when state changes", () => {
     // Simple class, copies state member `a` to `b`.
-    class Fixture extends ReactiveMixin(HTMLElement) {
+    // @ts-ignore - no idea how to fix the tsc error :(
+    class Fixture extends ReactiveMixin(Object) {
       get [internal.defaultState]() {
         const state = super[internal.defaultState];
         state.onChange("a", state => ({ b: state.a }));
@@ -171,7 +172,8 @@ describe("ReactiveMixin", function() {
   });
 
   it("runs state change handlers on initial state", () => {
-    class Fixture extends ReactiveMixin(HTMLElement) {
+    // @ts-ignore - no idea how to fix the tsc error :(
+    class Fixture extends ReactiveMixin(Object) {
       get [internal.defaultState]() {
         const state = super[internal.defaultState];
         state.a = 1;

--- a/test/tests/SelectedItemTextValueMixin.tests.js
+++ b/test/tests/SelectedItemTextValueMixin.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import SingleSelectionMixin from "../../src/SingleSelectionMixin.js";
 import SelectedItemTextValueMixin from "../../src/SelectedItemTextValueMixin.js";
 

--- a/test/tests/SelectedItemTextValueMixin.tests.js
+++ b/test/tests/SelectedItemTextValueMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import SingleSelectionMixin from "../../src/SingleSelectionMixin.js";
 import SelectedItemTextValueMixin from "../../src/SelectedItemTextValueMixin.js";
 

--- a/test/tests/SelectionInViewMixin.tests.js
+++ b/test/tests/SelectionInViewMixin.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import ReactiveMixin from "../../src/ReactiveMixin.js";
 import SelectionInViewMixin from "../../src/SelectionInViewMixin.js";

--- a/test/tests/SelectionInViewMixin.tests.js
+++ b/test/tests/SelectionInViewMixin.tests.js
@@ -2,11 +2,12 @@ import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import ReactiveMixin from "../../src/ReactiveMixin.js";
 import SelectionInViewMixin from "../../src/SelectionInViewMixin.js";
+import ShadowTemplateMixin from '../../src/ShadowTemplateMixin.js';
 
-const itemHeight = "100";
+const itemHeight = 100;
 
 class SelectionInViewTest extends SelectionInViewMixin(
-  ReactiveMixin(HTMLElement)
+  ReactiveMixin(ShadowTemplateMixin(HTMLElement))
 ) {
   connectedCallback() {
     super.connectedCallback();

--- a/test/tests/SelectionInViewMixin.tests.js
+++ b/test/tests/SelectionInViewMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import ReactiveMixin from "../../src/ReactiveMixin.js";
 import SelectionInViewMixin from "../../src/SelectionInViewMixin.js";

--- a/test/tests/ShadowTemplateMixin.tests.js
+++ b/test/tests/ShadowTemplateMixin.tests.js
@@ -86,12 +86,14 @@ describe("ShadowTemplateMixin", () => {
   it("stamps string template into root", () => {
     const fixture = new ElementWithStringTemplate();
     assert(fixture.shadowRoot);
+    // @ts-ignore prevent tsc error "`*.shadowRoot` might be null"
     assert.equal(fixture.shadowRoot.textContent.trim(), "Hello");
   });
 
   it("stamps real template into root", () => {
     const fixture = new ElementWithRealTemplate();
     assert(fixture.shadowRoot);
+    // @ts-ignore prevent tsc error "`*.shadowRoot` might be null"
     assert.equal(fixture.shadowRoot.textContent.trim(), "Hello");
   });
 
@@ -103,15 +105,19 @@ describe("ShadowTemplateMixin", () => {
 
   it("caches the template for a component", () => {
     const fixture1 = new ElementWithCachedTemplate();
+    // @ts-ignore prevent tsc error "`*.shadowRoot` might be null"
     assert.equal(fixture1.shadowRoot.textContent.trim(), "0");
     const fixture2 = new ElementWithCachedTemplate();
+    // @ts-ignore prevent tsc error "`*.shadowRoot` might be null"
     assert.equal(fixture2.shadowRoot.textContent.trim(), "0");
   });
 
   it("retrieves a dynamic template each time", () => {
     const fixture1 = new ElementWithDynamicTemplate();
+    // @ts-ignore prevent tsc error "`*.shadowRoot` might be null"
     assert.equal(fixture1.shadowRoot.textContent.trim(), "0");
     const fixture2 = new ElementWithDynamicTemplate();
+    // @ts-ignore prevent tsc error "`*.shadowRoot` might be null"
     assert.equal(fixture2.shadowRoot.textContent.trim(), "1");
   });
 });

--- a/test/tests/ShadowTemplateMixin.tests.js
+++ b/test/tests/ShadowTemplateMixin.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import * as template from "../../src/template.js";
 import ShadowTemplateMixin from "../../src/ShadowTemplateMixin.js";

--- a/test/tests/ShadowTemplateMixin.tests.js
+++ b/test/tests/ShadowTemplateMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import * as template from "../../src/template.js";
 import ShadowTemplateMixin from "../../src/ShadowTemplateMixin.js";

--- a/test/tests/SingleSelectionMixin.tests.js
+++ b/test/tests/SingleSelectionMixin.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import ReactiveMixin from "../../src/ReactiveMixin.js";
 import SingleSelectionMixin from "../../src/SingleSelectionMixin.js";

--- a/test/tests/SingleSelectionMixin.tests.js
+++ b/test/tests/SingleSelectionMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import ReactiveMixin from "../../src/ReactiveMixin.js";
 import SingleSelectionMixin from "../../src/SingleSelectionMixin.js";

--- a/test/tests/SingleSelectionMixin.tests.js
+++ b/test/tests/SingleSelectionMixin.tests.js
@@ -193,6 +193,7 @@ describe("SingleSelectionMixin", () => {
 
   it("ignores a selectedIndex that's not a number", () => {
     const fixture = createSampleElement();
+    // @ts-ignore
     fixture.selectedIndex = "foo";
     assert.equal(fixture.selectedIndex, -1);
   });

--- a/test/tests/SlotContentMixin.tests.js
+++ b/test/tests/SlotContentMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import SlotContentMixin from "../../src/SlotContentMixin.js";
 

--- a/test/tests/SlotContentMixin.tests.js
+++ b/test/tests/SlotContentMixin.tests.js
@@ -9,6 +9,7 @@ class SlotContentTest extends SlotContentMixin(HTMLElement) {
   constructor() {
     super();
     this.attachShadow({ mode: "open" });
+    // @ts-ignore prevent tsc error "`this.shadowRoot` might be null"
     this.shadowRoot.innerHTML = `
       <div id="static">This is static content</div>
       <slot></slot>
@@ -36,6 +37,7 @@ class WrappedContentTest extends HTMLElement {
   constructor() {
     super();
     this.attachShadow({ mode: "open" });
+    // @ts-ignore prevent tsc error "`this.shadowRoot` might be null"
     this.shadowRoot.innerHTML = `<slot-content-test><slot></slot></default-slotcontent-test>`;
   }
 }
@@ -56,6 +58,7 @@ describe("SlotContentMixin", () => {
     const fixture = new SlotContentTest();
     // Wait for initial content.
     await Promise.resolve();
+    // @ts-ignore prevent tsc error "`fixture.shadowRoot` might be null"
     const slot = fixture.shadowRoot.children[1];
     assert.equal(fixture[internal.contentSlot], slot);
   });
@@ -71,9 +74,11 @@ describe("SlotContentMixin", () => {
   it("returns distributed nodes as content", async () => {
     const wrapper = new WrappedContentTest();
     wrapper.innerHTML = `<div>One</div><div>Two</div><div>Three</div>`;
+    // @ts-ignore prevent tsc error "`wrapper.shadowRoot` might be null"
     const fixture = wrapper.shadowRoot.querySelector("slot-content-test");
     // Wait for initial content.
     await Promise.resolve();
+    // @ts-ignore prevent tsc error "`fixture` might be null"
     assert.equal(fixture[internal.state].content.length, 3);
   });
 
@@ -109,12 +114,14 @@ describe("SlotContentMixin", () => {
 
   it("updates content when redistributed content changes", async () => {
     const wrapper = new WrappedContentTest();
+    // @ts-ignore prevent tsc error "`wrapper.shadowRoot` might be null"
     const fixture = wrapper.shadowRoot.querySelector("slot-content-test");
     container.appendChild(wrapper);
     // Wait for initial content.
     wrapper.textContent = "echidna";
     // Wait for slotchange event to be processed.
     await Promise.resolve();
+    // @ts-ignore prevent tsc error "`fixture` might be null"
     assert.equal(fixture[internal.state].content[0].textContent, "echidna");
   });
 

--- a/test/tests/SlotContentMixin.tests.js
+++ b/test/tests/SlotContentMixin.tests.js
@@ -5,6 +5,7 @@ import SlotContentMixin from "../../src/SlotContentMixin.js";
 /*
  * Simple element using the SlotContentMixin mixin.
  */
+// @ts-ignore I have no idea what the tsc error means here :( 
 class SlotContentTest extends SlotContentMixin(HTMLElement) {
   constructor() {
     super();

--- a/test/tests/SlotContentMixin.tests.js
+++ b/test/tests/SlotContentMixin.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import SlotContentMixin from "../../src/SlotContentMixin.js";
 

--- a/test/tests/State.tests.js
+++ b/test/tests/State.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import State from "../../src/State.js";
 
 describe("State", () => {

--- a/test/tests/State.tests.js
+++ b/test/tests/State.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import State from "../../src/State.js";
 
 describe("State", () => {

--- a/test/tests/State.tests.js
+++ b/test/tests/State.tests.js
@@ -84,6 +84,7 @@ describe("State", () => {
     const state1 = new State();
     state1.onChange("b", () => {
       ranRule = true;
+      return null;
     });
 
     state1.copyWithChanges({ a: 1 });

--- a/test/tests/TapSelectionMixin.tests.js
+++ b/test/tests/TapSelectionMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import * as mockInteractions from "../mockInteractions.js";
 import ReactiveMixin from "../../src/ReactiveMixin.js";

--- a/test/tests/TapSelectionMixin.tests.js
+++ b/test/tests/TapSelectionMixin.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import * as mockInteractions from "../mockInteractions.js";
 import ReactiveMixin from "../../src/ReactiveMixin.js";

--- a/test/tests/TapSelectionMixin.tests.js
+++ b/test/tests/TapSelectionMixin.tests.js
@@ -3,8 +3,9 @@ import * as internal from "../../src/internal.js";
 import * as mockInteractions from "../mockInteractions.js";
 import ReactiveMixin from "../../src/ReactiveMixin.js";
 import TapSelectionMixin from "../../src/TapSelectionMixin.js";
+import ShadowTemplateMixin from '../../src/ShadowTemplateMixin.js';
 
-class TapSelectionTest extends TapSelectionMixin(ReactiveMixin(HTMLElement)) {
+class TapSelectionTest extends TapSelectionMixin(ReactiveMixin(ShadowTemplateMixin(HTMLElement))) {
   connectedCallback() {
     super.connectedCallback();
     const items = Array.prototype.slice.call(this.children);

--- a/test/tests/TransitionEffectMixin.tests.js
+++ b/test/tests/TransitionEffectMixin.tests.js
@@ -61,8 +61,8 @@ describe("TransitionEffectMixin", function() {
     container.appendChild(fixture);
     const states = [];
     fixture.addEventListener("effect-phase-changed", event => {
-      states.push(event.detail.effectPhase);
-      if (event.detail.effectPhase === "after") {
+      states.push(event["detail"].effectPhase);
+      if (event["detail"].effectPhase === "after") {
         assert.deepEqual(states, ["before", "during", "after"]);
         done();
       }
@@ -76,8 +76,8 @@ describe("TransitionEffectMixin", function() {
     container.appendChild(fixture);
     const states = [];
     fixture.addEventListener("effect-phase-changed", event => {
-      states.push(event.detail.effectPhase);
-      if (event.detail.effectPhase === "after") {
+      states.push(event["detail"].effectPhase);
+      if (event["detail"].effectPhase === "after") {
         assert.deepEqual(states, ["before", "during", "after"]);
         done();
       }

--- a/test/tests/TransitionEffectMixin.tests.js
+++ b/test/tests/TransitionEffectMixin.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import * as template from "../../src/template.js";
 import ReactiveElement from "../../src/ReactiveElement.js";

--- a/test/tests/TransitionEffectMixin.tests.js
+++ b/test/tests/TransitionEffectMixin.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import * as template from "../../src/template.js";
 import ReactiveElement from "../../src/ReactiveElement.js";

--- a/test/tests/WrappedStandardElement.tests.js
+++ b/test/tests/WrappedStandardElement.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import WrappedStandardElement from "../../src/WrappedStandardElement.js";
 

--- a/test/tests/WrappedStandardElement.tests.js
+++ b/test/tests/WrappedStandardElement.tests.js
@@ -103,12 +103,12 @@ describe("WrappedStandardElement", () => {
     // Disable via attribute.
     fixture.setAttribute("disabled", "");
     fixture[internal.renderChanges]();
-    assert.propertyVal(fixture.inner, "disabled", "");
+    assert.propertyVal(fixture.inner, "disabled", true);
 
     // Re-enable via attribute.
     fixture.removeAttribute("disabled");
     fixture[internal.renderChanges]();
-    assert.notProperty(fixture.inner, "disabled");
+    assert.propertyVal(fixture.inner, "disabled", false);
   });
 
   it("delegates tabindex state to inner element", async () => {

--- a/test/tests/WrappedStandardElement.tests.js
+++ b/test/tests/WrappedStandardElement.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import WrappedStandardElement from "../../src/WrappedStandardElement.js";
 

--- a/test/tests/WrappedStandardElement.tests.js
+++ b/test/tests/WrappedStandardElement.tests.js
@@ -38,7 +38,7 @@ describe("WrappedStandardElement", () => {
     const fixture = new WrappedA();
     fixture.href = "http://localhost/foo/bar.html";
     container.appendChild(fixture);
-    assert.equal(fixture.inner.href, "http://localhost/foo/bar.html");
+    assert.propertyVal(fixture.inner, "href", "http://localhost/foo/bar.html");
     assert.equal(fixture.protocol, "http:");
     assert.equal(fixture.hostname, "localhost");
     assert.equal(fixture.pathname, "/foo/bar.html");
@@ -49,7 +49,7 @@ describe("WrappedStandardElement", () => {
     container.appendChild(fixture);
     fixture.setAttribute("href", "http://example.com/");
     fixture[internal.renderChanges]();
-    assert.equal(fixture.inner.href, "http://example.com/");
+    assert.propertyVal(fixture.inner, "href", "http://example.com/");
   });
 
   it("re-raises events not automatically retargetted by Shadow DOM", done => {
@@ -93,22 +93,22 @@ describe("WrappedStandardElement", () => {
     // Disable via property.
     fixture.disabled = true;
     fixture[internal.renderChanges]();
-    assert(fixture.inner.disabled);
+    assert.propertyVal(fixture.inner, "disabled", true);
 
     // // Re-enable via property.
     fixture.disabled = false;
     fixture[internal.renderChanges]();
-    assert(!fixture.inner.disabled);
+    assert.propertyVal(fixture.inner, "disabled", false);
 
     // Disable via attribute.
     fixture.setAttribute("disabled", "");
     fixture[internal.renderChanges]();
-    assert(fixture.inner.disabled);
+    assert.propertyVal(fixture.inner, "disabled", "");
 
     // Re-enable via attribute.
     fixture.removeAttribute("disabled");
     fixture[internal.renderChanges]();
-    assert(!fixture.inner.disabled);
+    assert.notProperty(fixture.inner, "disabled");
   });
 
   it("delegates tabindex state to inner element", async () => {

--- a/test/tests/calendar.tests.js
+++ b/test/tests/calendar.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as calendar from "../../src/calendar.js";
 
 describe("calendar helpers", () => {

--- a/test/tests/calendar.tests.js
+++ b/test/tests/calendar.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import {assert} from '../test-helpers.js';
 import * as calendar from "../../src/calendar.js";
 
 describe("calendar helpers", () => {

--- a/test/tests/content.tests.js
+++ b/test/tests/content.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as content from "../../src/content.js";
 import * as internal from "../../src/internal.js";
 import * as template from "../../src/template.js";

--- a/test/tests/content.tests.js
+++ b/test/tests/content.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as content from "../../src/content.js";
 import * as internal from "../../src/internal.js";
 import * as template from "../../src/template.js";

--- a/test/tests/template.tests.js
+++ b/test/tests/template.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import * as internal from "../../src/internal.js";
 import * as template from "../../src/template.js";
 import ReactiveElement from "../../src/ReactiveElement.js";

--- a/test/tests/template.tests.js
+++ b/test/tests/template.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import * as internal from "../../src/internal.js";
 import * as template from "../../src/template.js";
 import ReactiveElement from "../../src/ReactiveElement.js";

--- a/test/tests/utilities.tests.js
+++ b/test/tests/utilities.tests.js
@@ -29,9 +29,9 @@ describe("utilities", () => {
       <slot></slot>
       <button id="enabled"></button>
     `;
-    fixture.attachShadow({ mode: "open" });
+    const shadowRoot = fixture.attachShadow({ mode: "open" });
     const shadowContent = document.importNode(fixtureTemplate.content, true);
-    fixture.shadowRoot.appendChild(shadowContent);
+    shadowRoot.appendChild(shadowContent);
     const childrenTemplate = template.html`
       <div>
         <input>
@@ -39,7 +39,7 @@ describe("utilities", () => {
     `;
     const childrenContent = document.importNode(childrenTemplate.content, true);
     fixture.appendChild(childrenContent);
-    const element = firstFocusableElement(fixture.shadowRoot);
+    const element = firstFocusableElement(shadowRoot);
     const input = fixture.querySelector("input");
     assert.equal(element, input);
   });

--- a/test/tests/utilities.tests.js
+++ b/test/tests/utilities.tests.js
@@ -1,3 +1,4 @@
+import { assert } from '../chai.js';
 import {
   applyChildNodes,
   composedAncestors,

--- a/test/tests/utilities.tests.js
+++ b/test/tests/utilities.tests.js
@@ -1,4 +1,4 @@
-import { assert } from '../chai.js';
+import { assert } from '../test-helpers.js';
 import {
   applyChildNodes,
   composedAncestors,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "strict": true,
     "target": "ES2019"
   },
-  "include": ["src/**/*.js", "demos/**/*.js", "tests/**/*.js"]
+  "include": ["src/**/*.js", "demos/**/*.js", "test/**/*.js"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "strict": true,
-    "target": "ES2019"
+    "target": "ES2019",
+    "allowSyntheticDefaultImports": true // just needed for sinon
   },
   "include": ["src/**/*.js", "demos/**/*.js", "test/**/*.js"]
 }


### PR DESCRIPTION
I was playing around with the typing and realized the tests did NOT get type checked, so I fixed the tsconfig.json to do so and a good number of type errors showed up. I fixed them and learned a lot about how to use tsc efficiently with JS code, thanks for the learning opportunity! :)

- [x] make typechecks also run against the tests
- [x] load all @types modules needed for the libraries used (mocha, sinon, chai)
- [x] built a test-helpers.js which allows tsc to find the types and the browser to use them from `window` I am sure there are better ways, than the old style way I did it
- [x] fixed all the type errors (that was fun)

There are a couple `// @ts-ignore` I introduced where I didn't know how to fix the typing errors, maybe someone has some ideas.