### PR TITLE
Improve elix-button Accessibility

### DIFF
--- a/demos/button.html
+++ b/demos/button.html
@@ -1,17 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>Elix Button</title>
 
-    <link rel="stylesheet" href="demos.css" />
-    <script type="module" src="../define/Button.js"></script>
-  </head>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Elix Button</title>
 
-  <body role="main">
-    <div class="demo">
-      <elix-button>Button</elix-button>
-    </div>
-  </body>
+  <link rel="stylesheet" href="demos.css" />
+  <script type="module" src="../define/Button.js"></script>
+</head>
+
+<body role="main">
+  <div class="demo">
+    <elix-button>Button</elix-button>
+  </div>
+</body>
+
 </html>

--- a/src/base/Button.d.ts
+++ b/src/base/Button.d.ts
@@ -1,12 +1,10 @@
 // Elix is a JavaScript project, but we define TypeScript declarations so we can
 // confirm our code is type safe, and to support TypeScript users.
 
-import AriaRoleMixin from "./AriaRoleMixin.js";
 import ComposedFocusMixin from "./ComposedFocusMixin.js";
 import FocusVisibleMixin from "./FocusVisibleMixin.js";
-import KeyboardMixin from "./KeyboardMixin.js";
 import WrappedStandardElement from "./WrappedStandardElement.js";
 
-export default class Button extends AriaRoleMixin(
-  ComposedFocusMixin(FocusVisibleMixin(KeyboardMixin(WrappedStandardElement)))
-) {}
+export default class Button extends
+  ComposedFocusMixin(FocusVisibleMixin(WrappedStandardElement)
+  ) { }

--- a/src/base/Button.js
+++ b/src/base/Button.js
@@ -1,32 +1,13 @@
 import { fragmentFrom } from "../core/htmlLiterals.js";
-import AriaRoleMixin from "./AriaRoleMixin.js";
 import ComposedFocusMixin from "./ComposedFocusMixin.js";
 import FocusVisibleMixin from "./FocusVisibleMixin.js";
-import { defaultState, keydown, state, tap, template } from "./internal.js";
-import KeyboardMixin from "./KeyboardMixin.js";
+import { defaultState, tap, template } from "./internal.js";
 import WrappedStandardElement from "./WrappedStandardElement.js";
 
-const Base = AriaRoleMixin(
+const Base =
   ComposedFocusMixin(
-    FocusVisibleMixin(KeyboardMixin(WrappedStandardElement.wrap("button")))
-  )
-);
-
-// Do we need to explicitly map Space/Enter keys to a button click?
-//
-// As of February 2019, Firefox automatically translates a Space/Enter key on a
-// button into a click event that bubbles to its host. Chrome/Safari do not do
-// this automatically, so we have to do it ourselves.
-//
-// It's gross to look for a specific browser (Firefox), but it seems extremely
-// hard to feature-detect this. Even if we try to create a button in a shadow at
-// runtime and send a key event to it, Chrome/Safari don't seem to do their
-// normal mapping of Space/Enter to a click for synthetic keyboard events.
-//
-// Firefox detection adapted from https://stackoverflow.com/a/9851769/76472
-// and adjusted to pass type checks.
-const firefox = "InstallTrigger" in window;
-const mapKeysToClick = !firefox;
+    FocusVisibleMixin(WrappedStandardElement.wrap("button"))
+  );
 
 /**
  * Base class for custom buttons.
@@ -35,45 +16,14 @@ const mapKeysToClick = !firefox;
  * and behavior while ensuring standard keyboard and focus behavior.
  *
  * @inherits WrappedStandardElement
- * @mixes AriaRoleMixin
  * @mixes ComposedFocusMixin
- * @mixes FocusVisibleMixin
  * @mixes KeyboardMixin
  */
 class Button extends Base {
   get [defaultState]() {
     return Object.assign(super[defaultState], {
       role: "button",
-      treatEnterAsClick: true,
-      treatSpaceAsClick: true,
     });
-  }
-
-  // Pressing Enter or Space raises a click event, as if the user had clicked
-  // the inner button.
-  // TODO: Space should raise the click on *keyup*.
-  [keydown](/** @type {KeyboardEvent} */ event) {
-    let handled;
-    if (mapKeysToClick) {
-      switch (event.key) {
-        case " ":
-          if (this[state].treatSpaceAsClick) {
-            this[tap]();
-            handled = true;
-          }
-          break;
-
-        case "Enter":
-          if (this[state].treatEnterAsClick) {
-            this[tap]();
-            handled = true;
-          }
-          break;
-      }
-    }
-
-    // Prefer mixin result if it's defined, otherwise use base result.
-    return handled || (super[keydown] && super[keydown](event));
   }
 
   // Respond to a simulated click.


### PR DESCRIPTION
Part of the proof of concept to make Elix more accessible.

**Changes:**
- removed the ariaRoleMixin, keyboardMixin from elix-button class
- removed code that manually checked if the user was on Firefox or if the user pressed space or enter key

**Why:**
- The reason space/enter wasn't working properly initially was because the button semantics were on the custom element - having role="button" on an element doesn't automatically make space/enter trigger the onClick event.
- It wasn't necessary to have role="button" on the element because there is an HTML button within it. Having both is confusing to the browser and assistive tech.
