### PR TITLE
elix-carousel: fix documentation for currentindexchange event

### DIFF
--- a/src/base/CursorAPIMixin.js
+++ b/src/base/CursorAPIMixin.js
@@ -166,7 +166,7 @@ export default function CursorAPIMixin(Base) {
         /**
          * Raised when the `currentIndex` property changes.
          *
-         * @event currentindexchanged
+         * @event currentindexchange
          */
         const event = new CustomEvent("currentindexchange", {
           bubbles: true,


### PR DESCRIPTION
Hi,

I assume that the documentation is wrong in this case as other events do not have past tense names and that the documentation is somehow created from the comments here as I couldn't find any occurrence of this name anywhere else.

fixes #171 